### PR TITLE
feat(terraform): add finops-core module scaffold

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,12 @@
+# Terraform Structure
+
+This directory holds reusable Terraform modules and compositions for the FinOps platform.
+
+## Layout
+
+- `modules/finops-core/`: baseline reusable module scaffold for shared resources
+
+## Notes
+
+- Terraform version target: `>= 1.6`
+- Modules are scaffolded first, then incrementally populated through milestone issues.

--- a/terraform/modules/finops-core/README.md
+++ b/terraform/modules/finops-core/README.md
@@ -1,0 +1,27 @@
+# finops-core module
+
+Reusable base module scaffold for FinOps platform infrastructure.
+
+## Purpose
+
+- Standardize baseline module interface (`name_prefix`, `environment`, `tags`)
+- Provide multi-cloud provider version constraints for future resource composition
+- Enable incremental implementation through milestone-linked issues
+
+## Usage
+
+```hcl
+module "finops_core" {
+  source      = "./modules/finops-core"
+  name_prefix = "finops"
+  environment = "dev"
+  tags = {
+    owner       = "platform"
+    environment = "dev"
+  }
+}
+```
+
+## Current scope
+
+Scaffold only. No resources are created yet.

--- a/terraform/modules/finops-core/main.tf
+++ b/terraform/modules/finops-core/main.tf
@@ -1,0 +1,10 @@
+locals {
+  module_context = {
+    name_prefix = var.name_prefix
+    environment = var.environment
+    tags        = var.tags
+  }
+}
+
+# Module scaffold intentionally contains no resources yet.
+# Resource composition is implemented incrementally via follow-up milestone issues.

--- a/terraform/modules/finops-core/outputs.tf
+++ b/terraform/modules/finops-core/outputs.tf
@@ -1,0 +1,4 @@
+output "module_context" {
+  description = "Echoes baseline module context for downstream composition."
+  value       = local.module_context
+}

--- a/terraform/modules/finops-core/variables.tf
+++ b/terraform/modules/finops-core/variables.tf
@@ -1,0 +1,15 @@
+variable "name_prefix" {
+  description = "Prefix used to name resources created by this module."
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment identifier (e.g. dev, stage, prod)."
+  type        = string
+}
+
+variable "tags" {
+  description = "Common tags/labels metadata for managed resources."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/finops-core/versions.tf
+++ b/terraform/modules/finops-core/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Objective
Implement issue #41 by creating the first reusable Terraform module scaffold for the FinOps platform.

## Scope
- add `terraform/modules/finops-core/` scaffold files
- add provider/version constraints in module `versions.tf`
- add baseline variables/outputs and README docs
- add root `terraform/README.md`

## Linked Issue
Closes #41

## Test Evidence
- [x] Structure and file presence validated
- [x] Terraform syntax-compatible scaffold committed
- [x] Scope limited to scaffolding (no resource creation)

## Risk and Rollback
- Risk level: low (documentation/scaffold only)
- Rollback strategy: revert this PR