### PR TITLE
feat(config): add reusable project configuration schema

### DIFF
--- a/config/examples/project-config.example.json
+++ b/config/examples/project-config.example.json
@@ -1,0 +1,10 @@
+{
+  "organization": "example-org",
+  "environment": "dev",
+  "provider": "gcp",
+  "billing_scope": "billing-account-123",
+  "tag_policy": {
+    "required_tags": ["owner", "environment", "service"],
+    "enforcement_mode": "audit"
+  }
+}

--- a/config/schema/project-config.schema.json
+++ b/config/schema/project-config.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/project-config.schema.json",
+  "title": "Project Configuration",
+  "type": "object",
+  "required": [
+    "organization",
+    "environment",
+    "provider",
+    "billing_scope",
+    "tag_policy"
+  ],
+  "properties": {
+    "organization": {
+      "type": "string",
+      "description": "Logical organization or tenant identifier.",
+      "minLength": 1
+    },
+    "environment": {
+      "type": "string",
+      "description": "Deployment environment (dev/stage/prod/etc).",
+      "minLength": 1
+    },
+    "provider": {
+      "type": "string",
+      "description": "Primary cloud provider.",
+      "enum": ["gcp", "aws", "azure", "multi"]
+    },
+    "billing_scope": {
+      "type": "string",
+      "description": "Billing account/scope identifier used for cost ingestion.",
+      "minLength": 1
+    },
+    "tag_policy": {
+      "type": "object",
+      "description": "Policy for mandatory ownership and allocation tags.",
+      "required": ["required_tags", "enforcement_mode"],
+      "properties": {
+        "required_tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "enforcement_mode": {
+          "type": "string",
+          "enum": ["audit", "enforce"]
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1,0 +1,37 @@
+# Configuration Schema
+
+This document defines the reusable baseline configuration contract for project onboarding.
+
+## Files
+
+- Schema: `config/schema/project-config.schema.json`
+- Example: `config/examples/project-config.example.json`
+- Validator: `scripts/validate_project_config.py`
+
+## Required top-level fields
+
+- `organization` (string)
+- `environment` (string)
+- `provider` (`gcp` | `aws` | `azure` | `multi`)
+- `billing_scope` (string)
+- `tag_policy` (object)
+
+## `tag_policy` fields
+
+- `required_tags` (non-empty string array)
+- `enforcement_mode` (`audit` | `enforce`)
+
+## Validation command
+
+```bash
+python scripts/validate_project_config.py config/examples/project-config.example.json
+```
+
+Expected output:
+
+- `OK: ... passed validation`
+
+## Notes
+
+- This is a bootstrap schema for early implementation phases.
+- Extend the schema incrementally in milestone-linked issues to avoid uncontrolled config sprawl.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,6 +8,7 @@ Deliverables:
 - Reusable architecture definition
 - Provider adapter contract
 - Parameterized configuration schema
+- Config schema validation utility and onboarding example
 
 Outcome:
 - New company onboarding by config only, no core rewrite.

--- a/scripts/validate_project_config.py
+++ b/scripts/validate_project_config.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Minimal config validation utility for project-config JSON files.
+
+This script intentionally performs a lightweight validation aligned with
+required schema fields so the project can bootstrap without extra dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+ALLOWED_PROVIDERS = {"gcp", "aws", "azure", "multi"}
+ALLOWED_ENFORCEMENT_MODES = {"audit", "enforce"}
+REQUIRED_FIELDS = {"organization", "environment", "provider", "billing_scope", "tag_policy"}
+
+
+def _load_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
+
+
+def validate_config(config: dict) -> list[str]:
+    errors: list[str] = []
+
+    missing = sorted(REQUIRED_FIELDS - set(config.keys()))
+    if missing:
+        errors.append(f"Missing required fields: {', '.join(missing)}")
+
+    for field in ("organization", "environment", "billing_scope"):
+        value = config.get(field)
+        if not isinstance(value, str) or not value.strip():
+            errors.append(f"Field '{field}' must be a non-empty string")
+
+    provider = config.get("provider")
+    if provider not in ALLOWED_PROVIDERS:
+        errors.append(f"Field 'provider' must be one of: {', '.join(sorted(ALLOWED_PROVIDERS))}")
+
+    tag_policy = config.get("tag_policy")
+    if not isinstance(tag_policy, dict):
+        errors.append("Field 'tag_policy' must be an object")
+        return errors
+
+    required_tags = tag_policy.get("required_tags")
+    if not isinstance(required_tags, list) or not required_tags:
+        errors.append("Field 'tag_policy.required_tags' must be a non-empty array")
+    else:
+        for tag in required_tags:
+            if not isinstance(tag, str) or not tag.strip():
+                errors.append("Each tag in 'tag_policy.required_tags' must be a non-empty string")
+                break
+
+    mode = tag_policy.get("enforcement_mode")
+    if mode not in ALLOWED_ENFORCEMENT_MODES:
+        errors.append(
+            "Field 'tag_policy.enforcement_mode' must be one of: "
+            + ", ".join(sorted(ALLOWED_ENFORCEMENT_MODES))
+        )
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate project config JSON")
+    parser.add_argument("config_path", type=Path, help="Path to config JSON file")
+    args = parser.parse_args()
+
+    config = _load_json(args.config_path)
+    errors = validate_config(config)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+
+    print(f"OK: {args.config_path} passed validation")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Objective
Implement issue #10 by introducing a reusable project configuration schema contract.

## Scope
- add JSON schema at `config/schema/project-config.schema.json`
- add example config at `config/examples/project-config.example.json`
- add validation utility `scripts/validate_project_config.py`
- document contract and usage in `docs/config-schema.md`
- update roadmap deliverables for schema-validation utility

## Linked Issue
Closes #10

## Test Evidence
- [x] `python scripts/validate_project_config.py config/examples/project-config.example.json`
- [x] Schema fields and required constraints documented
- [x] Scope limited to issue #10 only

## Risk and Rollback
- Risk level: low
- Rollback strategy: revert this PR