### PR TITLE
feat(adapters): define provider adapter contract and stubs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,3 +61,10 @@ flowchart LR
 - Core rules/scoring remain reusable across clouds.
 - Governance artifacts (runbooks, review cadence, DoD) are first-class.
 - Security by default: least privilege, no secrets in code, auditable automation.
+
+## Adapter Contract
+
+Provider adapter contract reference:
+
+- `docs/provider-adapter-contract.md`
+- `scripts/adapters/base.py`

--- a/docs/provider-adapter-contract.md
+++ b/docs/provider-adapter-contract.md
@@ -1,0 +1,57 @@
+# Provider Adapter Contract
+
+This document defines the provider adapter interface contract used by cloud-specific collectors.
+
+## Intent
+
+- Keep core FinOps logic provider-agnostic.
+- Isolate provider API differences in dedicated adapters.
+- Enforce a normalized output contract for downstream rules and dashboards.
+
+## Adapter Responsibilities
+
+Each provider adapter must:
+
+1. Collect inventory metadata.
+2. Collect utilization signals.
+3. Collect cost records.
+4. Normalize outputs to shared record formats.
+5. Return structured errors without crashing the full pipeline.
+
+## Required Methods
+
+- `fetch_inventory(scope: dict) -> list[dict]`
+- `fetch_utilization(scope: dict) -> list[dict]`
+- `fetch_costs(scope: dict) -> list[dict]`
+- `normalize(records: list[dict]) -> list[dict]`
+- `healthcheck() -> dict`
+
+## Normalized Record Fields (minimum)
+
+- `provider` (`gcp` | `aws` | `azure`)
+- `resource_id`
+- `resource_type`
+- `environment`
+- `owner`
+- `service`
+- `region`
+- `cost_amount`
+- `cost_currency`
+- `usage_quantity`
+- `usage_unit`
+- `timestamp`
+
+## Error Model
+
+Adapter errors should include:
+
+- `provider`
+- `stage` (`inventory|utilization|cost|normalize|healthcheck`)
+- `code`
+- `message`
+- `retryable` (`true|false`)
+
+## Notes
+
+- This contract is intentionally minimal for bootstrap phase.
+- Expand fields and strict typing in later milestones once real provider ingestion starts.

--- a/scripts/adapters/__init__.py
+++ b/scripts/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Provider adapter package."""

--- a/scripts/adapters/aws.py
+++ b/scripts/adapters/aws.py
@@ -1,0 +1,24 @@
+"""AWS adapter stub implementing ProviderAdapter contract."""
+
+from __future__ import annotations
+
+from .base import ProviderAdapter
+
+
+class AWSAdapter(ProviderAdapter):
+    provider = "aws"
+
+    def fetch_inventory(self, scope: dict) -> list[dict]:
+        return []
+
+    def fetch_utilization(self, scope: dict) -> list[dict]:
+        return []
+
+    def fetch_costs(self, scope: dict) -> list[dict]:
+        return []
+
+    def normalize(self, records: list[dict]) -> list[dict]:
+        return records
+
+    def healthcheck(self) -> dict:
+        return {"provider": self.provider, "status": "ok", "ready": True}

--- a/scripts/adapters/azure.py
+++ b/scripts/adapters/azure.py
@@ -1,0 +1,24 @@
+"""Azure adapter stub implementing ProviderAdapter contract."""
+
+from __future__ import annotations
+
+from .base import ProviderAdapter
+
+
+class AzureAdapter(ProviderAdapter):
+    provider = "azure"
+
+    def fetch_inventory(self, scope: dict) -> list[dict]:
+        return []
+
+    def fetch_utilization(self, scope: dict) -> list[dict]:
+        return []
+
+    def fetch_costs(self, scope: dict) -> list[dict]:
+        return []
+
+    def normalize(self, records: list[dict]) -> list[dict]:
+        return records
+
+    def healthcheck(self) -> dict:
+        return {"provider": self.provider, "status": "ok", "ready": True}

--- a/scripts/adapters/base.py
+++ b/scripts/adapters/base.py
@@ -1,0 +1,31 @@
+"""Base provider adapter contract."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class ProviderAdapter(ABC):
+    """Abstract contract implemented by each cloud provider adapter."""
+
+    provider: str
+
+    @abstractmethod
+    def fetch_inventory(self, scope: dict) -> list[dict]:
+        """Collect inventory metadata from provider APIs."""
+
+    @abstractmethod
+    def fetch_utilization(self, scope: dict) -> list[dict]:
+        """Collect utilization metrics/signals from provider APIs."""
+
+    @abstractmethod
+    def fetch_costs(self, scope: dict) -> list[dict]:
+        """Collect billing/cost data from provider APIs."""
+
+    @abstractmethod
+    def normalize(self, records: list[dict]) -> list[dict]:
+        """Normalize provider records to common output contract."""
+
+    @abstractmethod
+    def healthcheck(self) -> dict:
+        """Return adapter health state."""

--- a/scripts/adapters/gcp.py
+++ b/scripts/adapters/gcp.py
@@ -1,0 +1,24 @@
+"""GCP adapter stub implementing ProviderAdapter contract."""
+
+from __future__ import annotations
+
+from .base import ProviderAdapter
+
+
+class GCPAdapter(ProviderAdapter):
+    provider = "gcp"
+
+    def fetch_inventory(self, scope: dict) -> list[dict]:
+        return []
+
+    def fetch_utilization(self, scope: dict) -> list[dict]:
+        return []
+
+    def fetch_costs(self, scope: dict) -> list[dict]:
+        return []
+
+    def normalize(self, records: list[dict]) -> list[dict]:
+        return records
+
+    def healthcheck(self) -> dict:
+        return {"provider": self.provider, "status": "ok", "ready": True}


### PR DESCRIPTION
## Objective
Implement issue #11 by defining the provider adapter interface contract and baseline cloud adapter stubs.

## Scope
- add contract documentation: `docs/provider-adapter-contract.md`
- add adapter abstract base contract: `scripts/adapters/base.py`
- add stub adapters: `gcp.py`, `aws.py`, `azure.py`
- link contract reference in architecture docs

## Linked Issue
Closes #11

## Test Evidence
- [x] Adapter smoke test:
  - `python - <<'PY' ...` imports adapters and validates `healthcheck()`
- [x] Contract fields/methods documented
- [x] Scope limited to issue #11 only

## Risk and Rollback
- Risk level: low
- Rollback strategy: revert this PR