### PR TITLE
feat(discovery): add scope matrix and ownership mapping baseline

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,6 +19,7 @@ Deliverables:
 - Scope matrix (accounts/regions/environments)
 - Tagging policy and ownership model
 - Baseline spend profile and optimization hypotheses
+- Explicit out-of-scope register with rationale
 
 Outcome:
 - Shared baseline for technical and business prioritization.

--- a/docs/scope-matrix.md
+++ b/docs/scope-matrix.md
@@ -1,0 +1,25 @@
+# Scope Matrix
+
+This matrix defines initial coverage for accounts/scopes, regions, and environments used during discovery.
+
+## In Scope
+
+| Platform | Scope ID | Region(s) | Environment(s) | Owner | Notes |
+| --- | --- | --- | --- | --- | --- |
+| GCP | `billing-account-123` | `europe-west1`, `us-central1` | `dev`, `prod` | `platform-team` | Initial provider baseline for early milestones |
+| AWS | `123456789012` | `eu-west-1` | `dev` | `platform-team` | Included for future adapter parity testing |
+| Azure | `00000000-0000-0000-0000-000000000000` | `westeurope` | `dev` | `platform-team` | Included for contract validation, not full ingestion yet |
+
+## Out of Scope (Current Phase)
+
+| Scope | Reason |
+| --- | --- |
+| Additional regions not listed above | Deferred to scaling milestone |
+| Non-production legacy accounts with no tagging policy | Requires cleanup policy before onboarding |
+| Any scope without owner mapping | Ownership required for accountability and showback/chargeback |
+
+## Ownership Mapping Rules
+
+- Each scoped account/subscription/project must have a named owner group.
+- Ownership must map to cost accountability paths used in review cadence.
+- Unowned scopes remain out of scope until ownership is established.


### PR DESCRIPTION
## Objective
Implement issue #12 by publishing the discovery scope matrix with ownership mapping.

## Scope
- add `docs/scope-matrix.md` with in-scope matrix and out-of-scope register
- add ownership mapping rules for accountability
- update roadmap deliverables for explicit out-of-scope tracking

## Linked Issue
Closes #12

## Test Evidence
- [x] Scope matrix includes platform/scope/region/environment/owner dimensions
- [x] Out-of-scope entries documented with rationale
- [x] Scope limited to issue #12 only

## Risk and Rollback
- Risk level: low
- Rollback strategy: revert this PR