### PR TITLE
docs(discovery): publish baseline spend and waste hypothesis report

### DIFF
--- a/docs/baseline-spend-report.md
+++ b/docs/baseline-spend-report.md
@@ -1,0 +1,39 @@
+# Baseline Spend and Waste Hypothesis Report
+
+## Objective
+
+Establish an initial spend baseline and ranked optimization hypotheses to guide early execution.
+
+## Baseline Summary (Illustrative)
+
+| Category | Monthly Spend (USD) | Share |
+| --- | ---: | ---: |
+| Compute | 32,000 | 45.7% |
+| Managed Databases | 18,000 | 25.7% |
+| Storage | 11,000 | 15.7% |
+| Networking | 6,000 | 8.6% |
+| Observability/Other | 3,000 | 4.3% |
+| **Total** | **70,000** | **100%** |
+
+## Top Spend Categories Identified
+
+1. Compute
+2. Managed Databases
+3. Storage
+
+These categories represent the highest leverage for initial optimization work.
+
+## Ranked Waste Hypotheses
+
+| Rank | Hypothesis | Category | Estimated Monthly Opportunity (USD) | Confidence |
+| ---: | --- | --- | ---: | --- |
+| 1 | Sustained idle/underutilized compute instances | Compute | 6,000 | High |
+| 2 | Overprovisioned managed database tiers | Managed Databases | 3,500 | Medium |
+| 3 | Orphaned snapshots and unattached volumes | Storage | 2,200 | Medium |
+| 4 | Non-critical workloads in premium regions/SKUs | Compute/Networking | 1,500 | Low |
+
+## Prioritization Notes
+
+- Prioritize hypotheses by impact first, then confidence.
+- Keep SLO guardrails explicit before rightsizing actions.
+- Validate each hypothesis with sampled evidence before automation.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,6 +21,7 @@ Deliverables:
 - Baseline spend profile and optimization hypotheses
 - Explicit out-of-scope register with rationale
 - Compliance computation utility for mandatory tagging KPI
+- Baseline report artifact with ranked optimization hypotheses
 
 Outcome:
 - Shared baseline for technical and business prioritization.


### PR DESCRIPTION
## Objective
Implement issue #14 by publishing baseline spend and waste hypotheses for discovery planning.

## Scope
- add baseline report document with category breakdown
- rank initial waste hypotheses with confidence and estimated opportunity
- update roadmap deliverables for baseline report artifact

## Linked Issue
Closes #14

## Test Evidence
- [x] Baseline report includes top spend categories
- [x] Ranked waste hypotheses documented
- [x] Scope limited to issue #14 only

## Risk and Rollback
- Risk level: low
- Rollback strategy: revert this PR