### PR TITLE
docs(schema): publish normalized cost and asset schema v1

### DIFF
--- a/config/examples/normalized-cost-asset.example.json
+++ b/config/examples/normalized-cost-asset.example.json
@@ -1,0 +1,19 @@
+[
+  {
+    "provider": "gcp",
+    "resource_id": "projects/example/zones/europe-west1-b/instances/vm-1",
+    "resource_type": "compute.instance",
+    "environment": "dev",
+    "owner": "platform-team",
+    "service": "finops-api",
+    "region": "europe-west1",
+    "cost_amount": 12.54,
+    "cost_currency": "USD",
+    "usage_quantity": 24,
+    "usage_unit": "hour",
+    "timestamp": "2026-04-17T00:00:00Z",
+    "tags": {
+      "cost_center": "CC-1001"
+    }
+  }
+]

--- a/config/schema/normalized-cost-asset.schema.json
+++ b/config/schema/normalized-cost-asset.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/normalized-cost-asset.schema.json",
+  "title": "Normalized Cost And Asset Record",
+  "type": "object",
+  "required": [
+    "provider",
+    "resource_id",
+    "resource_type",
+    "environment",
+    "owner",
+    "service",
+    "region",
+    "cost_amount",
+    "cost_currency",
+    "usage_quantity",
+    "usage_unit",
+    "timestamp"
+  ],
+  "properties": {
+    "provider": {
+      "type": "string",
+      "enum": ["gcp", "aws", "azure"]
+    },
+    "resource_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "resource_type": {
+      "type": "string",
+      "minLength": 1
+    },
+    "environment": {
+      "type": "string",
+      "minLength": 1
+    },
+    "owner": {
+      "type": "string",
+      "minLength": 1
+    },
+    "service": {
+      "type": "string",
+      "minLength": 1
+    },
+    "region": {
+      "type": "string",
+      "minLength": 1
+    },
+    "cost_amount": {
+      "type": "number",
+      "minimum": 0
+    },
+    "cost_currency": {
+      "type": "string",
+      "pattern": "^[A-Z]{3}$"
+    },
+    "usage_quantity": {
+      "type": "number",
+      "minimum": 0
+    },
+    "usage_unit": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "tags": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/normalized-schema-v1.md
+++ b/docs/normalized-schema-v1.md
@@ -1,0 +1,35 @@
+# Normalized Cost and Asset Schema v1
+
+This schema defines the canonical record format used by provider collectors.
+
+## Files
+
+- Schema: `config/schema/normalized-cost-asset.schema.json`
+- Example: `config/examples/normalized-cost-asset.example.json`
+
+## Goals
+
+- Standardize provider outputs for downstream rules and dashboards.
+- Ensure core fields required for allocation and prioritization are always present.
+- Keep versioned contract stable across adapters.
+
+## Required Fields
+
+- `provider`
+- `resource_id`
+- `resource_type`
+- `environment`
+- `owner`
+- `service`
+- `region`
+- `cost_amount`
+- `cost_currency`
+- `usage_quantity`
+- `usage_unit`
+- `timestamp`
+
+## Versioning Rules
+
+- Breaking field changes require schema version bump.
+- New optional fields can be introduced in minor updates.
+- Adapter outputs must remain backward-compatible with v1 consumers.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,6 +32,7 @@ Deliverables:
 - Normalized schema v1
 - GCP collectors (inventory, utilization, cost)
 - Data quality and freshness checks
+- Example normalized records for contract validation
 
 Outcome:
 - Reliable telemetry foundation for optimization decisions.


### PR DESCRIPTION
## Objective
Implement issue #15 by publishing the normalized cost and asset schema v1.

## Scope
- add schema contract `config/schema/normalized-cost-asset.schema.json`
- add example normalized payload `config/examples/normalized-cost-asset.example.json`
- add schema documentation and versioning rules in `docs/normalized-schema-v1.md`
- update roadmap deliverables with normalized example artifact

## Linked Issue
Closes #15

## Test Evidence
- [x] JSON syntax validation for schema and example via Python loader
- [x] Required fields and versioning rules documented
- [x] Scope limited to issue #15 only

## Risk and Rollback
- Risk level: low
- Rollback strategy: revert this PR