### PR TITLE
feat(detection): implement idle compute detection rule set

### DIFF
--- a/config/examples/compute-utilization.sample.json
+++ b/config/examples/compute-utilization.sample.json
@@ -1,0 +1,18 @@
+[
+  {
+    "provider": "gcp",
+    "resource_id": "projects/example/zones/europe-west1-b/instances/vm-idle-1",
+    "resource_type": "compute.instance",
+    "avg_cpu_percent": 3.1,
+    "active_hours": 120,
+    "estimated_monthly_cost_usd": 240
+  },
+  {
+    "provider": "gcp",
+    "resource_id": "projects/example/zones/europe-west1-b/instances/vm-busy-1",
+    "resource_type": "compute.instance",
+    "avg_cpu_percent": 42.0,
+    "active_hours": 120,
+    "estimated_monthly_cost_usd": 260
+  }
+]

--- a/docs/idle-compute-rules.md
+++ b/docs/idle-compute-rules.md
@@ -1,0 +1,38 @@
+# Idle Compute Detection Rules
+
+## Purpose
+
+Identify compute instances with sustained low utilization and quantify savings opportunity.
+
+## Rule v1
+
+- Resource type must be `compute.instance`
+- `avg_cpu_percent < 10`
+- `active_hours >= 24`
+
+## Inputs
+
+- `config/examples/compute-utilization.sample.json`
+
+## Script
+
+- `scripts/detect_idle_compute.py`
+
+## Run
+
+```bash
+python scripts/detect_idle_compute.py \
+  --input config/examples/compute-utilization.sample.json \
+  --output tmp/detection/idle-compute-findings.json \
+  --cpu-threshold 10 \
+  --min-hours 24
+```
+
+## Output
+
+- Idle findings list with:
+  - `resource_id`
+  - `avg_cpu_percent`
+  - `active_hours`
+  - `estimated_monthly_savings_usd`
+  - `reason`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -45,6 +45,7 @@ Deliverables:
 - Idle compute rules
 - Orphaned storage/artifact rules
 - Priority scoring model
+- Detection runbooks with sample inputs and generated findings
 
 Outcome:
 - Ranked, actionable savings opportunities.

--- a/scripts/detect_idle_compute.py
+++ b/scripts/detect_idle_compute.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Detect idle compute candidates from utilization records."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def detect_idle(records: list[dict], cpu_threshold: float, min_hours: int) -> list[dict]:
+    findings: list[dict] = []
+    for rec in records:
+        if rec.get("resource_type") != "compute.instance":
+            continue
+        avg_cpu = float(rec.get("avg_cpu_percent", 0))
+        active_hours = int(rec.get("active_hours", 0))
+        if avg_cpu < cpu_threshold and active_hours >= min_hours:
+            findings.append(
+                {
+                    "resource_id": rec.get("resource_id"),
+                    "provider": rec.get("provider"),
+                    "avg_cpu_percent": avg_cpu,
+                    "active_hours": active_hours,
+                    "estimated_monthly_savings_usd": round(float(rec.get("estimated_monthly_cost_usd", 0)) * 0.6, 2),
+                    "reason": f"avg_cpu_percent < {cpu_threshold} for >= {min_hours}h",
+                }
+            )
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Detect idle compute resources")
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--cpu-threshold", type=float, default=10.0)
+    parser.add_argument("--min-hours", type=int, default=24)
+    args = parser.parse_args()
+
+    records = json.loads(args.input.read_text(encoding="utf-8"))
+    findings = detect_idle(records, args.cpu_threshold, args.min_hours)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(findings, indent=2), encoding="utf-8")
+    print(f"OK: wrote {len(findings)} idle compute findings")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Objective
Implement issue #18 by adding idle compute detection logic and rule documentation.

## Scope
- add idle compute detector script
- add sample utilization dataset
- add idle rule runbook and execution instructions
- update roadmap with detection runbook deliverable

## Linked Issue
Closes #18

## Test Evidence
- [x] `python scripts/detect_idle_compute.py --input config/examples/compute-utilization.sample.json --output tmp/detection/idle-compute-findings.json --cpu-threshold 10 --min-hours 24`
- [x] Detection output includes one expected idle finding
- [x] Scope limited to issue #18 only

## Risk and Rollback
- Risk level: low
- Rollback strategy: revert this PR