### PR TITLE
docs(dashboard): add executive cost opportunity dashboard artifact

### DIFF
--- a/dashboards/grafana/executive-cost-opportunity.dashboard.json
+++ b/dashboards/grafana/executive-cost-opportunity.dashboard.json
@@ -1,0 +1,66 @@
+{
+  "title": "FinOps Executive - Cost and Opportunity",
+  "description": "Executive summary of spend trend, optimization opportunity, and realized savings.",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "tags": ["finops", "executive", "phase4"],
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Monthly Cloud Spend (USD)",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(finops_monthly_spend_usd)"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Addressable Opportunity (USD)",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(finops_opportunity_monthly_usd)"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Spend Trend by Provider",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by(provider) (finops_daily_spend_usd)"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "bargauge",
+      "title": "Top Opportunity Types",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "topk(5, sum by(type) (finops_opportunity_monthly_usd))"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Realized Savings MTD (USD)",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(finops_realized_savings_mtd_usd)"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/executive-dashboard.md
+++ b/docs/executive-dashboard.md
@@ -1,0 +1,28 @@
+# Executive Dashboard
+
+## Artifact
+
+- Dashboard JSON: `dashboards/grafana/executive-cost-opportunity.dashboard.json`
+
+## Purpose
+
+Provide leadership-level visibility across spend trend, optimization opportunity size, and realized savings.
+
+## KPI Links
+
+All KPI formulas used by this dashboard are defined in:
+
+- `docs/kpi-definitions.md`
+
+## Drill-Down Path
+
+1. Start from executive aggregate panels (spend, opportunity, realized savings).
+2. Drill down by provider from spend trend panel.
+3. Drill down by opportunity type from top opportunity panel.
+4. Jump to team action queue dashboard for owner-level execution.
+
+## Import Example (Grafana)
+
+1. Open Grafana dashboard import.
+2. Upload `dashboards/grafana/executive-cost-opportunity.dashboard.json`.
+3. Map data source to the FinOps metrics backend.

--- a/docs/kpi-definitions.md
+++ b/docs/kpi-definitions.md
@@ -1,0 +1,21 @@
+# KPI Definitions
+
+## Executive KPIs
+
+- `Monthly Cloud Spend (USD)`: Sum of cloud cost for the active month across providers.
+- `Addressable Opportunity (USD)`: Sum of estimated monthly savings from currently open optimization findings.
+- `Realized Savings MTD (USD)`: Sum of savings from actions completed in current month.
+- `Spend Trend by Provider`: Daily spend grouped by provider (`gcp`, `aws`, `azure`).
+- `Top Opportunity Types`: Opportunity value grouped by finding type (`idle_compute`, `orphaned_storage`, `rightsizing`).
+
+## Ownership and Accountability KPIs
+
+- `Open Actions by Owner`: Count of findings assigned to each owner.
+- `Aging Actions > 14 Days`: Open findings with no state change for more than 14 days.
+- `Priority Score Coverage`: Ratio of open findings with valid `priority_score`.
+- `Tag Compliance`: Percentage of resources with mandatory tags.
+
+## KPI Governance
+
+- KPI formulas are immutable within a minor release.
+- Any KPI formula change requires ADR entry and changelog note.


### PR DESCRIPTION
## Objective
Implement issue #21 by publishing the executive dashboard artifact and linked KPI/drill-down documentation.

## Scope
- add Grafana executive dashboard JSON
- add KPI definitions documentation
- add executive dashboard drill-down guidance

## Linked Issue
Closes #21

## Test Evidence
- [x] `python -m json.tool dashboards/grafana/executive-cost-opportunity.dashboard.json`
- [x] Dashboard artifact and linked docs committed
- [x] Scope limited to issue #21 only

## Risk and Rollback
- Risk level: low
- Rollback strategy: revert this PR