### PR TITLE
feat(dashboard): add team action queue and ownership views

### DIFF
--- a/config/examples/action-queue.sample.json
+++ b/config/examples/action-queue.sample.json
@@ -1,0 +1,23 @@
+[
+  {
+    "resource_id": "vm-idle-1",
+    "type": "idle_compute",
+    "owner": "team-platform",
+    "priority_score": 120.0,
+    "estimated_monthly_savings_usd": 120.0
+  },
+  {
+    "resource_id": "disk-orphan-1",
+    "type": "orphaned_storage",
+    "owner": "team-data",
+    "priority_score": 48.0,
+    "estimated_monthly_savings_usd": 64.0
+  },
+  {
+    "resource_id": "db-rightsize-1",
+    "type": "rightsizing",
+    "owner": "team-app",
+    "priority_score": 90.0,
+    "estimated_monthly_savings_usd": 300.0
+  }
+]

--- a/dashboards/grafana/team-action-queue.dashboard.json
+++ b/dashboards/grafana/team-action-queue.dashboard.json
@@ -1,0 +1,47 @@
+{
+  "title": "FinOps Team Action Queue",
+  "description": "Owner-level queue for optimization actions sorted by priority score.",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "tags": ["finops", "operations", "phase4"],
+  "panels": [
+    {
+      "id": 1,
+      "type": "table",
+      "title": "Action Queue by Owner",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "finops_action_queue"
+        }
+      ],
+      "options": {
+        "showHeader": true
+      }
+    },
+    {
+      "id": 2,
+      "type": "bar gauge",
+      "title": "Open Actions by Owner",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "count by(owner) (finops_action_queue_open)"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Unassigned Actions",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "count(finops_action_queue{owner=\"unassigned\"})"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/team-action-queue.md
+++ b/docs/team-action-queue.md
@@ -1,0 +1,31 @@
+# Team Action Queue and Ownership Views
+
+## Artifacts
+
+- Dashboard JSON: `dashboards/grafana/team-action-queue.dashboard.json`
+- Queue builder script: `scripts/build_action_queue.py`
+- Sample queue input: `config/examples/action-queue.sample.json`
+
+## Team-Level Views
+
+- Table view: actionable findings with owner and priority score.
+- Aggregate view: open action count per owner.
+- Hygiene view: unassigned action count.
+
+## Owner Field Policy
+
+- Each action requires an `owner` value.
+- Missing owner values are normalized to `unassigned`.
+- `unassigned` items are tracked as operational debt.
+
+## Priority Sorting
+
+Queue items are sorted descending on `priority_score` to ensure teams execute highest-value actions first.
+
+## Run
+
+```bash
+python scripts/build_action_queue.py \
+  --input config/examples/action-queue.sample.json \
+  --output tmp/dashboard/action-queue.json
+```

--- a/scripts/build_action_queue.py
+++ b/scripts/build_action_queue.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Build owner-based action queue sorted by priority."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def build_queue(records: list[dict]) -> list[dict]:
+    enriched = []
+    for rec in records:
+        item = dict(rec)
+        owner = item.get("owner")
+        if not owner:
+            item["owner"] = "unassigned"
+        item["priority_score"] = float(item.get("priority_score", 0))
+        enriched.append(item)
+    return sorted(enriched, key=lambda x: x["priority_score"], reverse=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build team action queue")
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    records = json.loads(args.input.read_text(encoding="utf-8"))
+    if not isinstance(records, list):
+        raise SystemExit("ERROR: input must be a JSON array")
+
+    queue = build_queue(records)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(queue, indent=2), encoding="utf-8")
+    print(f"OK: wrote {len(queue)} queue items")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Objective
Implement issue #22 by adding team action queue views with owner attribution and priority sorting.

## Scope
- add owner-based action queue builder script
- add sample queue input with owner fields
- add Grafana team dashboard artifact and usage documentation

## Linked Issue
Closes #22

## Test Evidence
- [x] `python scripts/build_action_queue.py --input config/examples/action-queue.sample.json --output tmp/dashboard/action-queue.json`
- [x] Output sorted by `priority_score` descending
- [x] Scope limited to issue #22 only

## Risk and Rollback
- Risk level: low
- Rollback strategy: revert this PR