### PR TITLE
feat(alerting): add anomaly and compliance drift alerting baseline

### DIFF
--- a/alerts/prometheus/finops-alerts.yaml
+++ b/alerts/prometheus/finops-alerts.yaml
@@ -1,0 +1,27 @@
+groups:
+  - name: finops-alerts
+    rules:
+      - alert: FinOpsSpendAnomalyHigh
+        expr: |
+          (
+            sum(finops_daily_spend_usd)
+            >
+            (avg_over_time(sum(finops_daily_spend_usd)[14d]) * 1.25)
+          )
+        for: 30m
+        labels:
+          severity: warning
+          category: anomaly
+        annotations:
+          summary: "Cloud spend anomaly detected"
+          description: "Current daily spend is more than 25% above 14-day baseline."
+
+      - alert: FinOpsTagComplianceDrift
+        expr: finops_tag_compliance_ratio < 0.90
+        for: 1h
+        labels:
+          severity: critical
+          category: compliance
+        annotations:
+          summary: "Tag compliance drift detected"
+          description: "Mandatory tag compliance dropped below 90% for at least one hour."

--- a/config/examples/alert-routing.sample.json
+++ b/config/examples/alert-routing.sample.json
@@ -1,0 +1,14 @@
+{
+  "routes": [
+    {
+      "alert": "FinOpsSpendAnomalyHigh",
+      "channel": "slack-finops-alerts",
+      "owner": "team-finops"
+    },
+    {
+      "alert": "FinOpsTagComplianceDrift",
+      "channel": "pagerduty-finops-oncall",
+      "owner": "team-platform-governance"
+    }
+  ]
+}

--- a/docs/alerting-runbook.md
+++ b/docs/alerting-runbook.md
@@ -1,0 +1,31 @@
+# Alerting Runbook
+
+## Alert Rules
+
+- Prometheus rule file: `alerts/prometheus/finops-alerts.yaml`
+- Spend anomaly threshold: 25% above 14-day average sustained for 30 minutes
+- Tag compliance drift threshold: compliance ratio below 90% sustained for 1 hour
+
+## Routing Configuration
+
+- Sample routing map: `config/examples/alert-routing.sample.json`
+- Routing validation script: `scripts/validate_alert_routing.py`
+
+## Validate Routing
+
+```bash
+python scripts/validate_alert_routing.py \
+  --input config/examples/alert-routing.sample.json
+```
+
+## Notification Policy
+
+- `FinOpsSpendAnomalyHigh` routes to FinOps Slack alert channel.
+- `FinOpsTagComplianceDrift` routes to governance on-call channel.
+
+## Triage Steps
+
+1. Confirm alert integrity against source metrics.
+2. Identify impacted provider/account scope.
+3. Open or update remediation issue with owner and ETA.
+4. Track closure and post-incident KPI impact.

--- a/scripts/validate_alert_routing.py
+++ b/scripts/validate_alert_routing.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Validate alert routing definitions for mandatory FinOps alerts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+REQUIRED_ALERTS = {"FinOpsSpendAnomalyHigh", "FinOpsTagComplianceDrift"}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate alert routing config")
+    parser.add_argument("--input", required=True, type=Path)
+    args = parser.parse_args()
+
+    payload = json.loads(args.input.read_text(encoding="utf-8"))
+    routes = payload.get("routes", [])
+    if not isinstance(routes, list):
+        raise SystemExit("ERROR: routes must be a list")
+
+    seen: set[str] = set()
+    for route in routes:
+        alert = route.get("alert")
+        channel = route.get("channel")
+        owner = route.get("owner")
+        if not alert or not channel or not owner:
+            raise SystemExit("ERROR: each route requires alert, channel, and owner")
+        seen.add(str(alert))
+
+    missing = sorted(REQUIRED_ALERTS - seen)
+    if missing:
+        raise SystemExit(f"ERROR: missing required alert routes: {', '.join(missing)}")
+
+    print(f"OK: validated {len(routes)} routes")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Objective
Implement issue #23 by adding alert thresholds, routing validation, and alert runbook documentation.

## Scope
- add Prometheus alert rules for spend anomaly and compliance drift
- add routing sample config and routing validation script
- add alerting runbook with threshold and triage guidance

## Linked Issue
Closes #23

## Test Evidence
- [x] `python scripts/validate_alert_routing.py --input config/examples/alert-routing.sample.json`
- [x] Required alert routes are present and validated
- [x] Scope limited to issue #23 only

## Risk and Rollback
- Risk level: low
- Rollback strategy: revert this PR