### PR TITLE
docs(runbooks): add triage remediation and savings verification

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,9 @@
+# Operational Runbooks
+
+| Runbook | Use when |
+|---------|----------|
+| [Anomaly triage](anomaly-triage.md) | Spend spike or forecast deviation alert fires |
+| [Remediation](remediation.md) | Confirmed waste or policy breach needs change |
+| [Savings verification](savings-verification.md) | Claim realized savings after remediation |
+
+Escalation default: owning team → FinOps lead → engineering director → CFO (budget impact only).

--- a/docs/runbooks/anomaly-triage.md
+++ b/docs/runbooks/anomaly-triage.md
@@ -1,0 +1,30 @@
+# Runbook: Anomaly Triage
+
+## Trigger
+
+- `FinOpsSpendAnomalyHigh` or manual review of spend dashboard
+
+## Steps
+
+1. **Confirm signal**  
+   - Compare current window to baseline in Prometheus / billing export.  
+   - Rule out ingestion delay, duplicate charge, or FX noise.
+
+2. **Classify**  
+   - **Expected**: new workload, seasonality, marketing campaign → document in week notes.  
+   - **Investigate**: unknown spike → open task with owner from resource tags.
+
+3. **Scope**  
+   - Provider, account/subscription, region, service, resource IDs where available.
+
+4. **Escalate**  
+   - No owner tag or no response in **2 business days** → FinOps lead assigns owner.  
+   - Suspected security or data exfil pattern → Security / Gov per RACI.
+
+5. **Close loop**  
+   - Record outcome: false positive, expected, or remediation ticket opened.
+
+## Evidence to attach
+
+- Query screenshot or exported metrics range  
+- Billing line item or cost table reference if available  

--- a/docs/runbooks/remediation.md
+++ b/docs/runbooks/remediation.md
@@ -1,0 +1,28 @@
+# Runbook: Remediation
+
+## Trigger
+
+- Confirmed optimization opportunity, compliance breach, or anomaly triage outcome
+
+## Steps
+
+1. **Plan**  
+   - Change type: rightsize, delete, reschedule, tag fix, reservation change.  
+   - Blast radius: HA, backups, dependencies.
+
+2. **Approve**  
+   - Production change: use standard change approval for the platform.  
+   - Destructive delete: require backup or snapshot confirmation where applicable.
+
+3. **Execute**  
+   - Apply change in maintenance window if needed.  
+   - Link change ticket ID to FinOps finding.
+
+4. **Verify**  
+   - Resource state matches intent (inventory, utilization).  
+   - Follow [Savings verification](savings-verification.md) for cost proof.
+
+## Escalation
+
+- Blocked dependency on another team → FinOps lead coordinates.  
+- Policy exception needed → governance queue per `docs/tag-policy.md`.

--- a/docs/runbooks/savings-verification.md
+++ b/docs/runbooks/savings-verification.md
@@ -1,0 +1,32 @@
+# Runbook: Savings Verification
+
+## Purpose
+
+Prove that a remediation reduced or avoided cost using **evidence**, not estimates alone.
+
+## Required evidence
+
+| Evidence | Rule |
+|----------|------|
+| Before window | Cost or usage for same scope **7–30 days** before change (billing export or metric query). |
+| After window | Same scope **7–30 days** after change, excluding unrelated churn. |
+| Attribution | Scope filter: account, project, resource ID, or tag set documented. |
+| Currency | Same currency; note FX if multi-currency. |
+
+## Metric
+
+- **Realized monthly savings** = baseline mean daily cost − post mean daily cost, scaled to 30 days, for comparable calendar periods.  
+- Document **confidence** (high if single resource; medium if shared pool).
+
+## Workflow
+
+1. Capture baseline numbers from approved source (export CSV path or query ID).  
+2. Capture post numbers after stabilization (minimum **7 days** unless resource deleted).  
+3. Store evidence links in the closed finding or ticket.  
+4. Roll up to executive dashboard `realized savings MTD` only after review.
+
+## Rejection criteria
+
+- No comparable before window.  
+- Scope changed (new traffic, new SKU) without adjustment.  
+- Savings only from one-time credits.


### PR DESCRIPTION
Closes #25

## Scope
- `docs/runbooks/` index + anomaly triage, remediation, savings verification
- escalation table in README
- evidence rules for verification
