### PR TITLE
feat(forecast): add spend baseline forecast and dashboard panel

### DIFF
--- a/config/examples/spend-history.sample.json
+++ b/config/examples/spend-history.sample.json
@@ -1,0 +1,8 @@
+[
+  { "period": "2024-01", "amount_usd": 100000 },
+  { "period": "2024-02", "amount_usd": 105000 },
+  { "period": "2024-03", "amount_usd": 102000 },
+  { "period": "2024-04", "amount_usd": 110000 },
+  { "period": "2024-05", "amount_usd": 108000 },
+  { "period": "2024-06", "amount_usd": 112000 }
+]

--- a/dashboards/grafana/spend-forecast-baseline.dashboard.json
+++ b/dashboards/grafana/spend-forecast-baseline.dashboard.json
@@ -1,0 +1,37 @@
+{
+  "title": "FinOps Spend Forecast Baseline",
+  "description": "Actual monthly spend vs moving-average forecast and MAPE panel.",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "tags": ["finops", "forecast", "phase6"],
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Monthly spend vs forecast",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "finops_monthly_spend_usd"
+        },
+        {
+          "refId": "B",
+          "expr": "finops_monthly_spend_forecast_usd"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Forecast MAPE % (walk-forward)",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "finops_spend_forecast_mape_percent"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/forecasting-baseline.md
+++ b/docs/forecasting-baseline.md
@@ -1,0 +1,32 @@
+# Spend Forecasting Baseline
+
+## Model
+
+- **Method**: trailing `N`-month moving average (`N` default `3`).
+- **Next period forecast**: mean of last `N` observed monthly totals (`amount_usd`).
+- **Error metric**: **MAPE (%)** on walk-forward one-step predictions: for each month `t` from `N` onward, predict `t` using months `t-N..t-1`, compare to actual at `t`.
+
+## Script
+
+- `scripts/forecast_spend.py`
+- Input: `config/examples/spend-history.sample.json`
+
+## Run
+
+```bash
+python scripts/forecast_spend.py \
+  --input config/examples/spend-history.sample.json \
+  --output tmp/forecast-output.json
+```
+
+## Dashboard
+
+- Grafana panel definitions: `dashboards/grafana/spend-forecast-baseline.dashboard.json`
+- Typical queries (after exporting metrics to Prometheus):
+
+  - Actual: `finops_monthly_spend_usd`
+  - Forecast: `finops_monthly_spend_forecast_usd`
+
+## Interpretation
+
+- Lower MAPE = more stable spend; re-fit window when MAPE drifts above agreed threshold (e.g. 15%).

--- a/scripts/forecast_spend.py
+++ b/scripts/forecast_spend.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Baseline spend forecast from monthly series (moving average + walk-forward MAPE)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def _mape(actual: list[float], predicted: list[float]) -> float:
+    errs = []
+    for a, p in zip(actual, predicted, strict=True):
+        if a == 0:
+            continue
+        errs.append(abs(a - p) / a)
+    return sum(errs) / len(errs) if errs else 0.0
+
+
+def forecast_series(rows: list[dict], window: int = 3) -> dict:
+    """Rows: {\"period\": str, \"amount_usd\": number}, sorted ascending by period."""
+    amounts = [float(r["amount_usd"]) for r in rows]
+    if len(amounts) < window + 1:
+        raise ValueError("need at least window+1 points for walk-forward MAPE")
+
+    preds: list[float] = []
+    acts: list[float] = []
+    for t in range(window, len(amounts)):
+        pred = sum(amounts[t - window : t]) / window
+        preds.append(pred)
+        acts.append(amounts[t])
+
+    mape = round(_mape(acts, preds) * 100, 2)
+    next_forecast = round(sum(amounts[-window:]) / window, 2)
+    return {
+        "forecast_next_period_usd": next_forecast,
+        "mape_percent_walk_forward": mape,
+        "window": window,
+        "points_used": len(amounts),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Baseline spend forecast")
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--window", type=int, default=3)
+    args = parser.parse_args()
+
+    rows = json.loads(args.input.read_text(encoding="utf-8"))
+    if not isinstance(rows, list):
+        raise SystemExit("ERROR: input must be JSON array")
+    rows = sorted(rows, key=lambda r: r["period"])
+    out = forecast_series(rows, window=args.window)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(out, indent=2), encoding="utf-8")
+    print(json.dumps(out))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #27

## Test Evidence
- `python scripts/forecast_spend.py --input config/examples/spend-history.sample.json --output /tmp/out.json`
