### PR TITLE
feat(dashboard): add preconfigured local validation stack

### DIFF
--- a/config/examples/finops-sample-metrics.prom
+++ b/config/examples/finops-sample-metrics.prom
@@ -1,0 +1,14 @@
+finops_monthly_spend_usd{provider="gcp"} 125000
+finops_monthly_spend_usd{provider="aws"} 60000
+finops_monthly_spend_usd{provider="azure"} 42000
+finops_opportunity_monthly_usd{provider="gcp",type="idle_compute"} 18000
+finops_opportunity_monthly_usd{provider="gcp",type="orphaned_storage"} 12000
+finops_opportunity_monthly_usd{provider="aws",type="rightsizing"} 9000
+finops_opportunity_monthly_usd{provider="azure",type="idle_compute"} 7000
+finops_realized_savings_mtd_usd 8000
+finops_tag_compliance_ratio{provider="gcp"} 0.94
+finops_tag_compliance_ratio{provider="aws"} 0.91
+finops_tag_compliance_ratio{provider="azure"} 0.89
+finops_action_queue{provider="gcp",owner="team-platform",resource_id="vm-idle-1"} 120
+finops_action_queue{provider="aws",owner="team-core",resource_id="ri-rightsize-1"} 90
+finops_action_queue{provider="azure",owner="team-data",resource_id="disk-orphan-1"} 48

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  pushgateway:
+    image: prom/pushgateway:latest
+    container_name: finops-pushgateway
+    ports:
+      - "9091:9091"
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: finops-prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+    volumes:
+      - ./ops/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+    depends_on:
+      - pushgateway
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: finops-grafana
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - ./ops/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./ops/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+    restart: unless-stopped

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,13 +47,30 @@ test -d docs
 Expected output:
 - command exits with status `0`
 
-## 5) Work with issues and milestones
+## 5) Local visual dashboard validation
+
+Use Docker Compose stack plus sample metric injection:
+
+```bash
+chmod +x scripts/local_dashboard_stack.sh scripts/inject_sample_metrics.sh
+./scripts/local_dashboard_stack.sh up
+./scripts/local_dashboard_stack.sh inject
+```
+
+Then open:
+
+- Grafana: `http://localhost:3000` (`admin` / `admin`)
+- Prometheus: `http://localhost:9090`
+
+Reference: `docs/local-dashboard-validation.md`
+
+## 6) Work with issues and milestones
 
 1. Pick an issue from current milestone.
 2. Create branch: `feat/<issue-id>-<slug>` or `chore/<issue-id>-<slug>`.
 3. Open PR with linked issue and test evidence.
 
-## 6) Verify board workflow
+## 7) Verify board workflow
 
 - Issue moves: `Todo` -> `In Progress` -> `Done`
 - Keep one active `In Progress` item at a time.

--- a/docs/local-dashboard-validation.md
+++ b/docs/local-dashboard-validation.md
@@ -1,0 +1,56 @@
+# Local Dashboard Validation (Docker Compose)
+
+Use this flow to get a visual dashboard validation environment in minutes.
+
+## Prerequisites
+
+- Docker with Compose plugin
+- Open local ports: `3000`, `9090`, `9091`
+
+## One-time commands
+
+From repository root:
+
+```bash
+chmod +x scripts/local_dashboard_stack.sh scripts/inject_sample_metrics.sh
+```
+
+## Start stack
+
+```bash
+./scripts/local_dashboard_stack.sh up
+```
+
+## Inject sample metrics
+
+```bash
+./scripts/local_dashboard_stack.sh inject
+```
+
+Sample metrics source:
+
+- `config/examples/finops-sample-metrics.prom`
+
+## Open UIs
+
+- Grafana: `http://localhost:3000` (`admin` / `admin`)
+- Prometheus: `http://localhost:9090`
+- Pushgateway: `http://localhost:9091`
+
+## Grafana preconfigured (no manual setup)
+
+Provisioning is automatic from:
+
+- datasource: `ops/grafana/provisioning/datasources/datasource.yml`
+- dashboards provider: `ops/grafana/provisioning/dashboards/dashboards.yml`
+- preloaded dashboard: `ops/grafana/dashboards/finops-local-validation.dashboard.json`
+
+After stack starts, open Grafana and go to dashboard:
+
+- `FinOps Local Validation`
+
+## Stop stack
+
+```bash
+./scripts/local_dashboard_stack.sh down
+```

--- a/ops/grafana/dashboards/finops-local-validation.dashboard.json
+++ b/ops/grafana/dashboards/finops-local-validation.dashboard.json
@@ -1,0 +1,81 @@
+{
+  "id": null,
+  "uid": "finops-local",
+  "title": "FinOps Local Validation",
+  "tags": ["finops", "local", "validation"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "editable": true,
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Monthly Spend by Provider",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus-local" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by(provider) (finops_monthly_spend_usd)",
+          "legendFormat": "{{provider}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "bargauge",
+      "title": "Opportunity by Provider",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus-local" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by(provider) (finops_opportunity_monthly_usd)",
+          "legendFormat": "{{provider}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Realized Savings MTD (USD)",
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus-local" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "finops_realized_savings_mtd_usd"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "table",
+      "title": "Action Queue (Owner/Provider/Resource)",
+      "gridPos": { "h": 12, "w": 16, "x": 8, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus-local" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "finops_action_queue"
+        }
+      ]
+    }
+  ],
+  "templating": { "list": [] },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  }
+}

--- a/ops/grafana/provisioning/dashboards/dashboards.yml
+++ b/ops/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: FinOps Local
+    orgId: 1
+    folder: FinOps
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/ops/grafana/provisioning/datasources/datasource.yml
+++ b/ops/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus-local
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/ops/prometheus/prometheus.yml
+++ b/ops/prometheus/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: pushgateway
+    static_configs:
+      - targets: ["pushgateway:9091"]

--- a/scripts/inject_sample_metrics.sh
+++ b/scripts/inject_sample_metrics.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+METRICS_FILE="${1:-config/examples/finops-sample-metrics.prom}"
+PUSHGATEWAY_URL="${PUSHGATEWAY_URL:-http://localhost:9091}"
+JOB_NAME="${JOB_NAME:-finops}"
+INSTANCE_NAME="${INSTANCE_NAME:-local}"
+
+if [[ ! -f "${METRICS_FILE}" ]]; then
+  echo "ERROR: metrics file not found: ${METRICS_FILE}" >&2
+  exit 1
+fi
+
+curl --fail --silent --show-error \
+  --data-binary @"${METRICS_FILE}" \
+  "${PUSHGATEWAY_URL}/metrics/job/${JOB_NAME}/instance/${INSTANCE_NAME}"
+
+echo "OK: injected metrics from ${METRICS_FILE}"

--- a/scripts/local_dashboard_stack.sh
+++ b/scripts/local_dashboard_stack.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION="${1:-}"
+
+if [[ -z "${ACTION}" ]]; then
+  echo "Usage: $0 <up|inject|down|status>" >&2
+  exit 1
+fi
+
+case "${ACTION}" in
+  up)
+    docker compose up -d
+    ;;
+  inject)
+    ./scripts/inject_sample_metrics.sh
+    ;;
+  down)
+    docker compose down
+    ;;
+  status)
+    docker compose ps
+    ;;
+  *)
+    echo "Unknown action: ${ACTION}" >&2
+    echo "Usage: $0 <up|inject|down|status>" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Objective
Closes #76

## Scope
- Add docker-compose local stack (Grafana, Prometheus, Pushgateway)
- Add sample metrics file and injection script
- Add Grafana provisioning (datasource + preloaded dashboard)
- Update local validation docs

## Validation
- 
- OK: injected metrics from config/examples/finops-sample-metrics.prom
- Grafana API returns  dashboard
